### PR TITLE
Fix documentation for building Debian package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ CURIParser
 ```bash
 $ git clone https://github.com/Zewo/uri_parser.git
 $ cd uri_parser
-$ make
+$ make package
 $ dpkg -i uri_parser.deb
 ```
 


### PR DESCRIPTION
`make` does not build the `uri_parser.deb`
