### PR TITLE
Remove self-referential link command

### DIFF
--- a/Sources/include/module.modulemap
+++ b/Sources/include/module.modulemap
@@ -1,5 +1,4 @@
 module CURIParser {
     header "uri_parser.h"
-    link "CURIParser"
     export *
 }


### PR DESCRIPTION
Issue Reference: https://github.com/Zewo/Zewo/issues/107

According to the Swift Package Manager's [documentation](https://github.com/apple/swift-package-manager/blob/master/Documentation/SystemModules.md) `link` is to be used for linking against system libraries, and not meant to be used in a self-referential manner.
